### PR TITLE
Pin pypa/gh-action-pypi-publish to v1.14.0 by commit SHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,4 +37,4 @@ jobs:
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@v1.14
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0


### PR DESCRIPTION
The previous reference `pypa/gh-action-pypi-publish@v1.14` does not resolve — the action only ships full `vX.Y.Z` tags, not abbreviated `vX.Y` ones. This broke the publish workflow on the v1.7.2 release ("Unable to resolve action ... unable to find version `v1.14`").

Pin to the v1.14.0 commit SHA rather than the floating tag so an upstream tag move can't silently swap the action under us (the publish job has `id-token: write` and uploads to PyPI).